### PR TITLE
Add perf baseline CI workflow, profiling tools, and M_matrix cache controls

### DIFF
--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -16,6 +16,11 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       RUN_PERF_BASELINE: "1"
+      PERF_BENCH_ROUNDS: "10"
+      PERF_BENCH_WARMUP_ROUNDS: "2"
+      PERF_THETA_STEP_DEG: "0.2"
+      PERF_WL_STEP_NM: "2.0"
+      PERF_H_STEP_NM: "2.0"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -1,0 +1,54 @@
+name: perf-baseline
+
+on:
+  pull_request:
+    paths:
+      - "SPPPy/**"
+      - "tests/**"
+      - "README.md"
+      - "requirements.txt"
+      - "pytest.ini"
+      - ".github/workflows/perf-baseline.yml"
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-22.04
+    env:
+      RUN_PERF_BASELINE: "1"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-benchmark line_profiler
+
+      - name: Run baseline benchmarks
+        run: |
+          mkdir -p artifacts/benchmark
+          pytest tests/test_performance_baseline.py \
+            --benchmark-only \
+            --benchmark-json artifacts/benchmark/benchmark.json
+
+      - name: Convert benchmark report to CSV
+        run: |
+          python tests/benchmark_to_csv.py \
+            --benchmark-json artifacts/benchmark/benchmark.json \
+            --csv-output artifacts/benchmark/benchmark_summary.csv
+
+      - name: Run profiling
+        run: |
+          python tests/profile_baseline.py --output-dir artifacts/profiling
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-baseline-artifacts
+          path: artifacts/

--- a/README.md
+++ b/README.md
@@ -172,9 +172,12 @@ MIT License
 ### Режим измерений
 
 - single-thread baseline
-- warmup: **5 итераций**
-- measured rounds: **30**
+- reference-режим (детальный): warmup **5**, measured rounds **30**
+- CI smoke-режим (быстрый): warmup **2**, measured rounds **10**
 - статистика в отчётах: mean, median, stddev, p95 (из данных pytest-benchmark)
+
+По умолчанию тесты используют reference-режим, но параметры можно переопределять переменными
+`PERF_BENCH_WARMUP_ROUNDS` и `PERF_BENCH_ROUNDS`.
 
 ### Фиксация машины CI для сопоставимости
 
@@ -185,6 +188,16 @@ MIT License
 - без параллельного запуска benchmark-job в рамках workflow
 
 Workflow `perf-baseline` запускается автоматически на `pull_request` (для изменений в коде/тестах baseline) и вручную через `workflow_dispatch`. Это делает сравнение между PR более сопоставимым.
+
+Чтобы не перегружать PR-пайплайн, в CI workflow используется smoke-конфигурация сеток:
+
+- `PERF_THETA_STEP_DEG=0.2`
+- `PERF_WL_STEP_NM=2.0`
+- `PERF_H_STEP_NM=2.0`
+- `PERF_BENCH_WARMUP_ROUNDS=2`
+- `PERF_BENCH_ROUNDS=10`
+
+Для более точного сравнения можно запускать reference-конфигурацию вручную (`workflow_dispatch`) с более плотной сеткой и 5/30.
 
 См. workflow: `.github/workflows/perf-baseline.yml`.
 

--- a/SPPPy/__init__.py
+++ b/SPPPy/__init__.py
@@ -9,6 +9,10 @@ from .materials import (
     CompositeDispersion,
     ScaledDispersion,
     DispersionABS,
+    clear_m_cache,
+    set_m_cache_limit,
+    get_m_cache_limit,
+    get_m_cache_size,
 )
 
 __all__ = [
@@ -22,4 +26,8 @@ __all__ = [
     "CompositeDispersion",
     "ScaledDispersion",
     "DispersionABS",
+    "clear_m_cache",
+    "set_m_cache_limit",
+    "get_m_cache_limit",
+    "get_m_cache_size",
 ]

--- a/SPPPy/materials.py
+++ b/SPPPy/materials.py
@@ -47,15 +47,42 @@ def hide_drop_layers():
 
 
 M_cache = {}
+_M_CACHE_MAXSIZE = 200_000
+
+
+def clear_m_cache():
+    """Clear global transfer-matrix cache used by ``M_matrix``."""
+    M_cache.clear()
+
+
+def set_m_cache_limit(maxsize: int):
+    """Set max number of entries for global ``M_matrix`` cache."""
+    global _M_CACHE_MAXSIZE
+    if maxsize <= 0:
+        raise ValueError("maxsize must be > 0")
+    _M_CACHE_MAXSIZE = int(maxsize)
+
+
+def get_m_cache_limit() -> int:
+    """Return max size of global ``M_matrix`` cache."""
+    return _M_CACHE_MAXSIZE
+
+
+def get_m_cache_size() -> int:
+    """Return current size of global ``M_matrix`` cache."""
+    return len(M_cache)
 
 
 def memoize_M(f):
     def decorate(*args):
         if args in M_cache:
             return M_cache[args]
-        else:
-            M_cache[args] = f(*args)
-            return M_cache[args]
+
+        if len(M_cache) >= _M_CACHE_MAXSIZE:
+            clear_m_cache()
+
+        M_cache[args] = f(*args)
+        return M_cache[args]
 
     return decorate
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    performance: performance/baseline benchmark tests

--- a/tests/benchmark_to_csv.py
+++ b/tests/benchmark_to_csv.py
@@ -1,0 +1,92 @@
+"""Convert pytest-benchmark JSON output into a concise CSV summary."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+
+
+CSV_COLUMNS = [
+    "name",
+    "scenario",
+    "mean_sec",
+    "stddev_sec",
+    "median_sec",
+    "iqr_sec",
+    "rounds",
+    "curves_count",
+    "curves_per_sec",
+    "theta_start_deg",
+    "theta_stop_deg",
+    "theta_step_deg",
+    "lambda_start_nm",
+    "lambda_stop_nm",
+    "lambda_step_nm",
+    "thickness_start_nm",
+    "thickness_stop_nm",
+    "thickness_step_nm",
+]
+
+
+def _safe_get(mapping: dict, *keys, default=""):
+    current = mapping
+    for key in keys:
+        if not isinstance(current, dict) or key not in current:
+            return default
+        current = current[key]
+    return current
+
+
+def convert(benchmark_json: Path, csv_output: Path) -> None:
+    """Read pytest-benchmark JSON report and write condensed CSV rows."""
+    with benchmark_json.open("r", encoding="utf-8") as f:
+        raw = json.load(f)
+
+    entries = raw.get("benchmarks", [])
+
+    csv_output.parent.mkdir(parents=True, exist_ok=True)
+    with csv_output.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=CSV_COLUMNS)
+        writer.writeheader()
+        for entry in entries:
+            stats = entry.get("stats", {})
+            extra = entry.get("extra_info", {})
+            grid = extra.get("grid", {})
+            writer.writerow(
+                {
+                    "name": entry.get("name", ""),
+                    "scenario": extra.get("scenario", ""),
+                    "mean_sec": stats.get("mean", ""),
+                    "stddev_sec": stats.get("stddev", ""),
+                    "median_sec": stats.get("median", ""),
+                    "iqr_sec": stats.get("iqr", ""),
+                    "rounds": stats.get("rounds", ""),
+                    "curves_count": extra.get("curves_count", ""),
+                    "curves_per_sec": extra.get("curves_per_sec", ""),
+                    "theta_start_deg": grid.get("theta_start_deg", ""),
+                    "theta_stop_deg": grid.get("theta_stop_deg", ""),
+                    "theta_step_deg": grid.get("theta_step_deg", ""),
+                    "lambda_start_nm": grid.get("lambda_start_nm", ""),
+                    "lambda_stop_nm": grid.get("lambda_stop_nm", ""),
+                    "lambda_step_nm": grid.get("lambda_step_nm", ""),
+                    "thickness_start_nm": grid.get("thickness_start_nm", ""),
+                    "thickness_stop_nm": grid.get("thickness_stop_nm", ""),
+                    "thickness_step_nm": grid.get("thickness_step_nm", ""),
+                }
+            )
+
+
+def main() -> None:
+    """CLI entrypoint for benchmark JSON -> CSV conversion."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--benchmark-json", required=True, type=Path)
+    parser.add_argument("--csv-output", required=True, type=Path)
+    args = parser.parse_args()
+
+    convert(args.benchmark_json, args.csv_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/profile_baseline.py
+++ b/tests/profile_baseline.py
@@ -1,0 +1,132 @@
+"""Two-stage profiling for baseline SPR API workloads.
+
+Stage 1: cProfile + pstats (top cumulative)
+Stage 2: optional line_profiler for hot paths
+"""
+
+from __future__ import annotations
+
+import argparse
+import cProfile
+import io
+import pstats
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from SPPPy import ExperimentSPR, Layer, MaterialDispersion, nm
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+BASE_CSV = BASE_DIR / "PermittivitiesBase.csv"
+
+
+def _grid(start: float, stop: float, step: float) -> np.ndarray:
+    count = int(round((stop - start) / step)) + 1
+    return np.linspace(start, stop, count)
+
+
+def _build_experiment() -> tuple[ExperimentSPR, Layer]:
+    exp = ExperimentSPR(polarization="p")
+    exp.add(Layer(MaterialDispersion("BK7", base_file=str(BASE_CSV)), 0, "Prism"))
+    exp.add(Layer(MaterialDispersion("Ag", base_file=str(BASE_CSV)), 55 * nm, "Ag"))
+    sio2_layer = Layer(MaterialDispersion("SiO2", base_file=str(BASE_CSV)), 0, "SiO2")
+    exp.add(sio2_layer)
+    exp.add(Layer(1.0, 0, "Air"))
+    return exp, sio2_layer
+
+
+def run_baseline_workload() -> float:
+    """Execute representative single-thread baseline workload and return checksum."""
+    exp, sio2_layer = _build_experiment()
+    theta_deg = _grid(40.0, 70.0, 0.2)
+    lambda_nm = _grid(450.0, 650.0, 2.0)
+    thickness_nm = _grid(0.0, 100.0, 2.0)
+
+    checksum = 0.0
+    for h_nm in thickness_nm:
+        sio2_layer.thickness = float(h_nm) * nm
+        # mixed workload across B + C flavors
+        curve_theta = np.array(exp.R(angle_range=theta_deg, wl_range=None, angle=None))
+        checksum += float(np.sum(curve_theta))
+
+        spectrum = [
+            float(np.abs(exp.R_deg(theta=float(theta_deg[0]), wl=float(wl) * nm)) ** 2)
+            for wl in lambda_nm
+        ]
+        checksum += float(np.sum(spectrum))
+
+    return checksum
+
+
+def run_cprofile(output_dir: Path, top_n: int = 25) -> None:
+    """Profile baseline workload with cProfile and save pstats artifacts."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    profile_path = output_dir / "baseline.cprofile"
+    txt_path = output_dir / "baseline_pstats.txt"
+
+    prof = cProfile.Profile()
+    prof.enable()
+    checksum = run_baseline_workload()
+    prof.disable()
+    prof.dump_stats(str(profile_path))
+
+    stream = io.StringIO()
+    stats = pstats.Stats(prof, stream=stream).sort_stats("cumulative")
+    stats.print_stats(top_n)
+    stream.write(f"\nchecksum={checksum}\n")
+    txt_path.write_text(stream.getvalue(), encoding="utf-8")
+
+
+def run_line_profiler(output_dir: Path) -> bool:
+    """Profile hot path with line_profiler when dependency is available."""
+    try:
+        # pylint: disable=import-outside-toplevel
+        from line_profiler import LineProfiler
+    except ImportError:
+        return False
+
+    # pylint: disable=import-outside-toplevel
+    from SPPPy.experiment import ExperimentSPR as ExperimentSPRImpl
+    from SPPPy.materials import DispersionABS
+    from SPPPy.materials import Layer as LayerImpl
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    txt_path = output_dir / "baseline_line_profiler.txt"
+
+    lp = LineProfiler()
+    lp.add_function(ExperimentSPRImpl.Transfer_matrix)
+    lp.add_function(LayerImpl.S_matrix)
+    lp.add_function(DispersionABS.CRI)
+
+    wrapped = lp(run_baseline_workload)
+    checksum = wrapped()
+
+    with txt_path.open("w", encoding="utf-8") as fh:
+        lp.print_stats(stream=fh)
+        fh.write(f"\nchecksum={checksum}\n")
+
+    return True
+
+
+def main() -> None:
+    """CLI entrypoint for two-stage profiling."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("artifacts/profiling"),
+        help="Directory where profiling artifacts will be written",
+    )
+    args = parser.parse_args()
+
+    run_cprofile(args.output_dir)
+    has_line_profiler = run_line_profiler(args.output_dir)
+    if not has_line_profiler:
+        print("line_profiler is not installed; skipped stage 2.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_m_cache_controls.py
+++ b/tests/test_m_cache_controls.py
@@ -1,0 +1,39 @@
+"""Tests for global M_matrix cache controls."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from SPPPy import clear_m_cache, get_m_cache_limit, get_m_cache_size, set_m_cache_limit
+from SPPPy.materials import M_matrix
+
+
+def test_m_cache_limit_validation():
+    """set_m_cache_limit must reject non-positive values."""
+    try:
+        set_m_cache_limit(0)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("Expected ValueError for non-positive cache limit")
+
+
+def test_m_cache_clear_on_limit_policy():
+    """Cache should be cleared when insertion reaches configured limit."""
+    old_limit = get_m_cache_limit()
+    try:
+        clear_m_cache()
+        set_m_cache_limit(2)
+
+        M_matrix(1.0, 0.1, 1.5, 1.0, 0.0, "p")
+        assert get_m_cache_size() == 1
+
+        M_matrix(1.1, 0.1, 1.5, 1.0, 0.0, "p")
+        assert get_m_cache_size() == 2
+
+        M_matrix(1.2, 0.1, 1.5, 1.0, 0.0, "p")
+        assert get_m_cache_size() == 1
+    finally:
+        set_m_cache_limit(old_limit)
+        clear_m_cache()

--- a/tests/test_performance_baseline.py
+++ b/tests/test_performance_baseline.py
@@ -23,6 +23,10 @@ def _float_env(name: str, default: float) -> float:
     return float(os.getenv(name, str(default)))
 
 
+def _int_env(name: str, default: int) -> int:
+    return int(os.getenv(name, str(default)))
+
+
 def _grid(start: float, stop: float, step: float) -> np.ndarray:
     count = int(round((stop - start) / step)) + 1
     return np.linspace(start, stop, count)
@@ -105,11 +109,14 @@ def _scenario_c(grids: dict) -> tuple[int, float]:
 
 def _run_benchmark(benchmark, scenario_name: str, runner):
     grids = _default_grids()
+    rounds = _int_env("PERF_BENCH_ROUNDS", 30)
+    warmup_rounds = _int_env("PERF_BENCH_WARMUP_ROUNDS", 5)
+
     curves_count, checksum = benchmark.pedantic(
         lambda: runner(grids),
-        rounds=30,
+        rounds=rounds,
         iterations=1,
-        warmup_rounds=5,
+        warmup_rounds=warmup_rounds,
     )
 
     stats = benchmark.stats.stats
@@ -146,6 +153,8 @@ def _run_benchmark(benchmark, scenario_name: str, runner):
             "curves_count": int(curves_count),
             "curves_per_sec": curves_per_sec,
             "checksum": float(checksum),
+            "rounds": rounds,
+            "warmup_rounds": warmup_rounds,
         }
     )
 

--- a/tests/test_performance_baseline.py
+++ b/tests/test_performance_baseline.py
@@ -1,0 +1,204 @@
+"""Performance baseline benchmarks for core API scenarios A/B/C."""
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# pylint: disable=wrong-import-position
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from SPPPy import ExperimentSPR, Layer, MaterialDispersion, nm
+
+_HAS_PYTEST_BENCHMARK = importlib.util.find_spec("pytest_benchmark") is not None
+BASE_DIR = Path(__file__).resolve().parents[1]
+BASE_CSV = BASE_DIR / "PermittivitiesBase.csv"
+
+
+def _float_env(name: str, default: float) -> float:
+    return float(os.getenv(name, str(default)))
+
+
+def _grid(start: float, stop: float, step: float) -> np.ndarray:
+    count = int(round((stop - start) / step)) + 1
+    return np.linspace(start, stop, count)
+
+
+def _default_grids() -> dict:
+    return {
+        "theta_deg": _grid(
+            _float_env("PERF_THETA_START_DEG", 40.0),
+            _float_env("PERF_THETA_STOP_DEG", 70.0),
+            _float_env("PERF_THETA_STEP_DEG", 0.1),
+        ),
+        "lambda_nm": _grid(
+            _float_env("PERF_WL_START_NM", 400.0),
+            _float_env("PERF_WL_STOP_NM", 700.0),
+            _float_env("PERF_WL_STEP_NM", 1.0),
+        ),
+        "thickness_nm": _grid(
+            _float_env("PERF_H_START_NM", 0.0),
+            _float_env("PERF_H_STOP_NM", 100.0),
+            _float_env("PERF_H_STEP_NM", 1.0),
+        ),
+    }
+
+
+def _build_experiment() -> tuple[ExperimentSPR, Layer]:
+    exp = ExperimentSPR(polarization="p")
+    bk7 = MaterialDispersion("BK7", base_file=str(BASE_CSV))
+    ag = MaterialDispersion("Ag", base_file=str(BASE_CSV))
+    sio2 = MaterialDispersion("SiO2", base_file=str(BASE_CSV))
+    exp.add(Layer(bk7, 0, "Prism"))
+    exp.add(Layer(ag, 55 * nm, "Ag"))
+    sio2_layer = Layer(sio2, 0 * nm, "SiO2")
+    exp.add(sio2_layer)
+    exp.add(Layer(1.0, 0, "Air"))
+    return exp, sio2_layer
+
+
+def _scenario_a(grids: dict) -> tuple[int, float]:
+    exp, sio2_layer = _build_experiment()
+    exp.wavelength = grids["lambda_nm"][0] * nm
+    theta = float(grids["theta_deg"][0])
+    checksum = 0.0
+
+    for thickness_nm in grids["thickness_nm"]:
+        sio2_layer.thickness = float(thickness_nm) * nm
+        checksum += float(np.abs(exp.R_deg(theta=theta)) ** 2)
+
+    return len(grids["thickness_nm"]), checksum
+
+
+def _scenario_b(grids: dict) -> tuple[int, float]:
+    exp, sio2_layer = _build_experiment()
+    theta = float(grids["theta_deg"][0])
+    checksum = 0.0
+
+    for thickness_nm in grids["thickness_nm"]:
+        sio2_layer.thickness = float(thickness_nm) * nm
+        spectrum = [
+            float(np.abs(exp.R_deg(theta=theta, wl=float(wl_nm) * nm)) ** 2)
+            for wl_nm in grids["lambda_nm"]
+        ]
+        checksum += float(np.sum(spectrum))
+
+    return len(grids["thickness_nm"]), checksum
+
+
+def _scenario_c(grids: dict) -> tuple[int, float]:
+    exp, sio2_layer = _build_experiment()
+    exp.wavelength = grids["lambda_nm"][0] * nm
+    checksum = 0.0
+
+    for thickness_nm in grids["thickness_nm"]:
+        sio2_layer.thickness = float(thickness_nm) * nm
+        curve = np.array(exp.R(angle_range=grids["theta_deg"]))
+        checksum += float(np.sum(curve))
+
+    return len(grids["thickness_nm"]), checksum
+
+
+def _run_benchmark(benchmark, scenario_name: str, runner):
+    grids = _default_grids()
+    curves_count, checksum = benchmark.pedantic(
+        lambda: runner(grids),
+        rounds=30,
+        iterations=1,
+        warmup_rounds=5,
+    )
+
+    stats = benchmark.stats.stats
+    mean_seconds = float(stats["mean"])
+    curves_per_sec = float(curves_count) / mean_seconds if mean_seconds > 0 else 0.0
+
+    benchmark.extra_info.update(
+        {
+            "scenario": scenario_name,
+            "curve_definition": {
+                "A": "1 curve = one scalar R at fixed (theta, lambda) for one thickness",
+                "B": "1 curve = one full R(lambda) array for one thickness",
+                "C": "1 curve = one full R(theta) array for one thickness",
+            },
+            "grid": {
+                "theta_start_deg": float(grids["theta_deg"][0]),
+                "theta_stop_deg": float(grids["theta_deg"][-1]),
+                "theta_step_deg": float(grids["theta_deg"][1] - grids["theta_deg"][0])
+                if len(grids["theta_deg"]) > 1
+                else 0.0,
+                "lambda_start_nm": float(grids["lambda_nm"][0]),
+                "lambda_stop_nm": float(grids["lambda_nm"][-1]),
+                "lambda_step_nm": float(grids["lambda_nm"][1] - grids["lambda_nm"][0])
+                if len(grids["lambda_nm"]) > 1
+                else 0.0,
+                "thickness_start_nm": float(grids["thickness_nm"][0]),
+                "thickness_stop_nm": float(grids["thickness_nm"][-1]),
+                "thickness_step_nm": float(
+                    grids["thickness_nm"][1] - grids["thickness_nm"][0]
+                )
+                if len(grids["thickness_nm"]) > 1
+                else 0.0,
+            },
+            "curves_count": int(curves_count),
+            "curves_per_sec": curves_per_sec,
+            "checksum": float(checksum),
+        }
+    )
+
+
+@pytest.mark.performance
+@pytest.mark.skipif(
+    os.getenv("RUN_PERF_BASELINE", "0") != "1",
+    reason="Performance baseline is opt-in. Set RUN_PERF_BASELINE=1.",
+)
+@pytest.mark.skipif(
+    not _HAS_PYTEST_BENCHMARK,
+    reason="pytest-benchmark is not installed",
+)
+def test_perf_scenario_a(benchmark):
+    """Benchmark scenario A: one scalar R per thickness value."""
+    _run_benchmark(benchmark, "A", _scenario_a)
+
+
+@pytest.mark.performance
+@pytest.mark.skipif(
+    os.getenv("RUN_PERF_BASELINE", "0") != "1",
+    reason="Performance baseline is opt-in. Set RUN_PERF_BASELINE=1.",
+)
+@pytest.mark.skipif(
+    not _HAS_PYTEST_BENCHMARK,
+    reason="pytest-benchmark is not installed",
+)
+def test_perf_scenario_b(benchmark):
+    """Benchmark scenario B: full R(lambda) sweep per thickness."""
+    _run_benchmark(benchmark, "B", _scenario_b)
+
+
+@pytest.mark.performance
+@pytest.mark.skipif(
+    os.getenv("RUN_PERF_BASELINE", "0") != "1",
+    reason="Performance baseline is opt-in. Set RUN_PERF_BASELINE=1.",
+)
+@pytest.mark.skipif(
+    not _HAS_PYTEST_BENCHMARK,
+    reason="pytest-benchmark is not installed",
+)
+def test_perf_scenario_c(benchmark):
+    """Benchmark scenario C: full R(theta) sweep per thickness."""
+    _run_benchmark(benchmark, "C", _scenario_c)
+
+
+def test_perf_curve_spec_is_serializable():
+    """Guardrail: benchmark metadata must be JSON serializable for CI artifact export."""
+    payload = {
+        "curve_definition": {
+            "A": "one scalar",
+            "B": "one lambda-array",
+            "C": "one theta-array",
+        }
+    }
+    json.dumps(payload)

--- a/tests/test_performance_baseline.py
+++ b/tests/test_performance_baseline.py
@@ -120,7 +120,10 @@ def _run_benchmark(benchmark, scenario_name: str, runner):
     )
 
     stats = benchmark.stats.stats
-    mean_seconds = float(stats["mean"])
+    mean_val = getattr(stats, "mean", None)
+    if mean_val is None:
+        mean_val = stats["mean"]
+    mean_seconds = float(mean_val)
     curves_per_sec = float(curves_count) / mean_seconds if mean_seconds > 0 else 0.0
 
     benchmark.extra_info.update(


### PR DESCRIPTION
### Motivation

- Provide a reproducible performance baseline for PRs and a compact KPI (`curves/sec`) for core SPR workloads.
- Add tooling to collect, convert and profile benchmark artifacts to make performance regressions visible and comparable across CI runs.
- Expose and control the global transfer-matrix cache to support performance experiments and deterministic cache policies.

### Description

- Add a GitHub Actions workflow `perf-baseline` in `.github/workflows/perf-baseline.yml` that runs baseline benchmarks on `ubuntu-22.04` with `Python 3.11` and uploads `artifacts/`.
- Extend `README.md` with a detailed Performance baseline specification, grids, KPI definitions, profiling instructions, and cache control API documentation for `SPPPy`.
- Introduce benchmark and profiling utilities: `tests/test_performance_baseline.py`, `tests/benchmark_to_csv.py`, and `tests/profile_baseline.py` to run pytest-benchmark, convert JSON->CSV, and produce cProfile/line_profiler outputs.
- Add pytest marker configuration in `pytest.ini` for `performance` tests.
- Add global cache controls to `SPPPy/materials.py`: `clear_m_cache`, `set_m_cache_limit`, `get_m_cache_limit`, `get_m_cache_size`, and implement a `clear-on-limit` policy in `memoize_M` with default `_M_CACHE_MAXSIZE = 200_000`.
- Export the new cache control APIs from `SPPPy/__init__.py` so they are available at package level.
- Add unit tests `tests/test_m_cache_controls.py` validating `set_m_cache_limit` validation and the clear-on-limit cache behavior.

### Testing

- Added unit tests `tests/test_m_cache_controls.py` and benchmark tests `tests/test_performance_baseline.py` which are intended to run under CI when `RUN_PERF_BASELINE=1` and `pytest-benchmark` is available.
- Added conversion and profiling scripts `tests/benchmark_to_csv.py` and `tests/profile_baseline.py` used by the workflow to produce CI artifacts.
- No automated tests were executed as part of this rollout; CI is expected to run the new workflow and tests after merging or when the workflow is triggered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e365b0504832eaae4a2240b5970af)